### PR TITLE
Add Pyrexp to "Wild Cards & Regex" in linuxshell.md

### DIFF
--- a/content/Engineering/Linux/linuxshell.md
+++ b/content/Engineering/Linux/linuxshell.md
@@ -373,6 +373,8 @@ Note that not all things that seem like a good fit are a good fit for regex, for
 
 [Crex (Octobanana git repo)](https://octobanana.com/software/crex) - "Explore, test, and check regular expressions in the terminal."
 
+[Pyrexp](https://pythonium.net/regex) - A regex tester that also allows visualization of the pattern graphically.
+
 Also see https://pomsky-lang.org as an alternative to regex.
 
 ## Job Control


### PR DESCRIPTION
Hello, I added Pyrexp (I am the founder), an online regex tester and visualizer (visualization of the pattern graphically), to resources of "Wild Cards & Regex" in linuxshell.md

##### 1) Public Domain

- [x] I agree to put my contribution into the Public Domain (or CC-0, if that doesn't apply where you are)
